### PR TITLE
Add simple personal site (index.html + styles.css)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>João Silva</title>
+    <meta
+      name="description"
+      content="Site pessoal de João Silva com textos sobre tecnologia, escrita e trabalho criativo."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1><a href="#">João Silva</a></h1>
+      <p class="tagline">escrevendo sobre código, produto e internet</p>
+    </header>
+
+    <main>
+      <section>
+        <h2>Textos recentes</h2>
+        <ul class="post-list">
+          <li>
+            <time datetime="2026-04-05">5 abr 2026</time>
+            <a href="#">Como usar IA sem perder o pensamento crítico</a>
+          </li>
+          <li>
+            <time datetime="2026-03-19">19 mar 2026</time>
+            <a href="#">Notas de arquitetura para projetos pequenos</a>
+          </li>
+          <li>
+            <time datetime="2026-02-27">27 fev 2026</time>
+            <a href="#">Escrever melhor documentação técnica</a>
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Sobre</h2>
+        <p>
+          Sou desenvolvedor e gosto de escrever sobre decisões de produto,
+          engenharia de software e hábitos de trabalho. Este site é um espaço
+          simples para publicar ideias sem distrações.
+        </p>
+      </section>
+
+      <section>
+        <h2>Links</h2>
+        <ul>
+          <li><a href="#">GitHub</a></li>
+          <li><a href="#">LinkedIn</a></li>
+          <li><a href="mailto:joao@example.com">Email</a></li>
+        </ul>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © 2026 João Silva • Feito com HTML e CSS.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,102 @@
+:root {
+  --bg: #fefefe;
+  --text: #111;
+  --link: #1439b2;
+  --muted: #666;
+  --accent: #c40000;
+  --rule: #d7d7d7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem 3rem;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Georgia, "Times New Roman", Times, serif;
+  line-height: 1.6;
+}
+
+.page-header,
+main,
+footer {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.page-header {
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+}
+
+h1,
+h2 {
+  font-weight: normal;
+  margin: 0;
+}
+
+h1 {
+  font-size: 2.25rem;
+  line-height: 1.1;
+}
+
+h1 a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.tagline {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-style: italic;
+}
+
+h2 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.6rem;
+  font-size: 1.5rem;
+}
+
+a {
+  color: var(--link);
+}
+
+a:hover {
+  text-decoration-thickness: 2px;
+}
+
+.post-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.post-list li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: baseline;
+  margin-bottom: 0.35rem;
+  flex-wrap: wrap;
+}
+
+time {
+  color: var(--muted);
+  min-width: 6.8rem;
+  font-variant-numeric: tabular-nums;
+}
+
+ul {
+  padding-left: 1.1rem;
+}
+
+footer {
+  margin-top: 2rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}


### PR DESCRIPTION
### Motivation
- Add a minimalist static personal site in Portuguese to publish short essays and links. 
- Provide a distraction-free layout for posts, an about section, and contact links. 
- Ship basic styling alongside the HTML so the site has consistent typography and spacing.

### Description
- Add `site/index.html` with metadata, a header, `main` sections for recent posts, an about blurb, links, and a footer. 
- Add `site/styles.css` implementing CSS custom properties, base typography, layout constraints, and simple responsive behaviors. 
- The HTML references `styles.css` and includes example posts with `time` elements and a `mailto:` link. 
- Visual design choices include a centered content column, typographic scale, and muted/link/accent color tokens.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d2a916a8f08321a534def3f8008c7a)